### PR TITLE
Error in CTS binary instantiation caused failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The majority of the lab will be performed using the contents of this folder, whi
 
 A setup script has been added to this repository to speed the time to deployment
 
-1. `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/CiscoDevNet/cts-esg-sample-code/master/setup.sh)"`
+1. `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/CiscoDevNet/cts-esg-sample-code/main/setup.sh)"`
 2. `cd cts-esg-sample-code/pre-req`
 3. `./terraform init`
 4. `./terraform plan -out tf.plan`

--- a/setup.sh
+++ b/setup.sh
@@ -9,9 +9,9 @@ echo "##################################################################"
 echo "# $(tput setaf 2)Downloading Consul-Terraform-Sync (CTS) binary.... $(tput setaf 7)#############"
 echo "##################################################################"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    curl https://releases.hashicorp.com/consul-terraform-sync/0.4.3/consul-terraform-sync_0.4.3_linux_amd64.zip -o cts-esg-sample-code/cts/cts.zip
+    curl https://releases.hashicorp.com/consul-terraform-sync/0.6.0/consul-terraform-sync_0.6.0_linux_amd64.zip -o cts-esg-sample-code/cts/cts.zip
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    curl https://releases.hashicorp.com/consul-terraform-sync/0.4.3/consul-terraform-sync_0.4.3_darwin_amd64.zip -o cts-esg-sample-code/cts/cts.zip
+    curl https://releases.hashicorp.com/consul-terraform-sync/0.6.0/consul-terraform-sync_0.6.0_darwin_amd64.zip -o cts-esg-sample-code/cts/cts.zip
 fi
 unzip cts-esg-sample-code/cts/cts.zip -d cts-esg-sample-code/cts/
 rm -rf cts-esg-sample-code/cts/cts.zip
@@ -20,9 +20,9 @@ echo "##################################################################"
 echo "# $(tput setaf 2)Downloading Terraform binary.... $(tput setaf 7)###############################"
 echo "##################################################################"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    curl https://releases.hashicorp.com/terraform/1.1.4/terraform_1.1.4_linux_amd64.zip -o cts-esg-sample-code/pre-req/tf.zip
+    curl https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_amd64.zip -o cts-esg-sample-code/pre-req/tf.zip
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    curl https://releases.hashicorp.com/terraform/1.1.4/terraform_1.1.4_darwin_amd64.zip -o cts-esg-sample-code/pre-req/tf.zip
+    curl https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_darwin_amd64.zip -o cts-esg-sample-code/pre-req/tf.zip
 fi
 unzip cts-esg-sample-code/pre-req/tf.zip -d cts-esg-sample-code/pre-req/
 rm -rf cts-esg-sample-code/pre-req/tf.zip


### PR DESCRIPTION
Failure to access log within `sync-tasks` folder created by CTS binary.  Updated CTS and TF versions to latest supported (0.6.0 for CTS, 1.1.9 for TF) and all seems to function correctly.